### PR TITLE
Report back an error message if schema initialization fails

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -918,6 +918,8 @@ paths:
           description: Initialization procedure has finished successfully.
         "401":
           description: On invalid secret.
+        "500":
+          description: On server side errors.
 
   /graph/refresh:
     post:

--- a/thoth/management_api/api_v1.py
+++ b/thoth/management_api/api_v1.py
@@ -247,7 +247,12 @@ def initialize_schema(secret: str):
 
     graph = GraphDatabase()
     graph.connect()
-    graph.initialize_schema()
+    try:
+        graph.initialize_schema()
+    except Exception as exc:
+        return {
+            "error": str(exc)
+        }, 500
 
     return {}, 201
 


### PR DESCRIPTION
This is usefull if there are server side errors. An example I observed - if
there is ongoing transaction on Dgraph side, Dgraph refuses to update schema
and an error is returned back to user.