### PR TITLE
Add Package Analyzer log & status endpoints

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1037,3 +1037,326 @@ paths:
                 required:
                   - analysis_id
                   - parameters
+
+  /package-analyzer/{analysis_id}:
+    get:
+      tags: [Python Analyzer]
+      x-openapi-router-controller: thoth.management_api.api_v1
+      operationId: get_analyze_package
+      summary: Retrieve a package analyzer result.
+      parameters:
+        - name: analysis_id
+          in: path
+          required: true
+          description: Document id to be retrieved.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Analyzer result retrieved.
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Result of an analysis
+                required:
+                  - metadata
+                  - result
+                properties:
+                  metadata:
+                    type: object
+                    description: Metadata for analysis run.
+                    required:
+                      - analyzer
+                      - analyzer_version
+                      - arguments
+                      - datetime
+                      - distribution
+                      - hostname
+                      - python
+                    properties:
+                      analyzer:
+                        type: string
+                        description: Analyzer name which handled analysis.
+                      analyzer_version:
+                        type: string
+                        description: Version of analyzer handling analysis.
+                      arguments:
+                        type: object
+                        description: Arguments passed to analyzer.
+                      datetime:
+                        type: string
+                        description: Date and time of analysis end in ISO format.
+                      distribution:
+                        type: object
+                        description: >
+                          Information about environment in which the analysis
+                          was performed.
+                        required:
+                          - codename
+                          - id
+                          - like
+                          - version
+                          - version_parts
+                        properties:
+                          codename:
+                            type: string
+                            description: >
+                              Codename of environment in which the analysis was perfomed.
+                          id:
+                            type: string
+                            description: >
+                              Identifier of environment in which the analysis
+                              was perfomed.
+                          like:
+                            type: string
+                            description: >
+                              Similar environments in comparision to environment in
+                              which the analysis was perfomed.
+                          version:
+                            type: string
+                            description: A string representation of environment version.
+                          version_parts:
+                            type: object
+                            description: >
+                              Parts of version identifier of the analysing environment.
+                            properties:
+                              build_number:
+                                type: string
+                              major:
+                                type: string
+                              minor:
+                                type: string
+                            required:
+                              - build_number
+                              - major
+                              - minor
+                      hostname:
+                        type: string
+                        description: Pod name where the analysis was done.
+                      python:
+                        required:
+                          - api_version
+                          - implementation_name
+                          - major
+                          - minor
+                          - micro
+                          - releaselevel
+                          - serial
+                        properties:
+                          api_version:
+                            type: integer
+                          implementation_name:
+                            type: string
+                            example: cpython
+                          major:
+                            type: integer
+                          micro:
+                            type: integer
+                          minor:
+                            type: integer
+                          releaselevel:
+                            type: string
+                            example: final
+                          serial:
+                            type: integer
+                  result:
+                    type: object
+                    description: Actual result of an analysis run.
+        "202":
+          description: Results are not ready yet.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - parameters
+                  - status
+                properties:
+                  error:
+                    type: string
+                    description: Error information for user.
+                  parameters:
+                    type: object
+                    description: Parameters echoed back to user for debugging.
+                  status:
+                    type: object
+                    description: Status information about the analysis run.
+                    required:
+                      - container
+                      - exit_code
+                      - finished_at
+                      - reason
+                      - started_at
+                      - state
+                    properties:
+                      container:
+                        type: string
+                        description: SHA of container image in which the analysis is done.
+                        nullable: true
+                      exit_code:
+                        type: integer
+                        description: Return code of the process perfoming analysis.
+                        nullable: true
+                      finished_at:
+                        type: string
+                        description: >
+                          Datetime in ISO format informing about when the analysis
+                          has finished.
+                        nullable: true
+                      reason:
+                        type: string
+                        description: Reasoning on finished run.
+                        nullable: true
+                      started_at:
+                        type: string
+                        nullable: true
+                        description: >
+                          Datetime in ISO format informing about when the analysis
+                          has started.
+                      state:
+                        type: string
+                        example: terminated
+                      parameters:
+                        type: object
+                        description: Parameters echoed back to user for debugging.
+        "400":
+          description: On invalid request.
+          content:
+            application/json:
+              schema: &analysisResponseError
+                type: object
+                required:
+                  - error
+                  - parameters
+                properties:
+                  error:
+                    type: string
+                    description: Error information for user.
+                  parameters:
+                    type: object
+                    description: Parameters echoed back to user for debugging.
+        "404":
+          description: The given document does not exist.
+          content:
+            application/json:
+              schema:
+                <<: *analysisResponseError
+
+  /package-analyzer/{analysis_id}/log:
+    get:
+      tags: [Python Analyzer]
+      x-openapi-router-controller: thoth.management_api.api_v1
+      operationId: get_analyze_package_log
+      summary: Retrieve a package analyzer log.
+      parameters:
+        - name: analysis_id
+          in: path
+          required: true
+          description: An id of analysis for a package-analyzer run.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Retrieved ecosystem package-analyzer log.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - log
+                  - parameters
+                properties:
+                  log:
+                    type: string
+                    description: Analyzer logs printed to stdout/stderr as a plain text.
+                    nullable: true
+                  parameters:
+                    type: object
+                    description: Parameters echoed back to user for debugging.
+        "400":
+          description: On invalid request.
+          content:
+            application/json:
+              schema:
+                <<: *analysisResponseError
+        "404":
+          description: The given solver log does not exist.
+          content:
+            application/json:
+              schema:
+                <<: *analysisResponseError
+
+  /package-analyzer/{analysis_id}/status:
+    get:
+      tags: [Python Analyzer]
+      x-openapi-router-controller: thoth.management_api.api_v1
+      operationId: get_analyze_package_status
+      summary: Show status of an ecosystem package-analyzer.
+      parameters:
+        - name: analysis_id
+          in: path
+          required: true
+          description: An id of requested ecosystem package-analyzer run.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema: &analysisStatus
+                type: object
+                description: Information about the current analysis status.
+                required:
+                  - parameters
+                  - status
+                properties:
+                  status:
+                    type: object
+                    description: Status information about the analysis run.
+                    required:
+                      - container
+                      - exit_code
+                      - finished_at
+                      - reason
+                      - started_at
+                      - state
+                    properties:
+                      container:
+                        type: string
+                        description: SHA of container image in which the analysis is done.
+                        nullable: true
+                      exit_code:
+                        type: integer
+                        description: Return code of the process perfoming analysis.
+                        nullable: true
+                      finished_at:
+                        type: string
+                        description: >
+                          Datetime in ISO format informing about when the analysis
+                          has finished.
+                        nullable: true
+                      reason:
+                        type: string
+                        description: Reasoning on finished run.
+                        nullable: true
+                      started_at:
+                        type: string
+                        nullable: true
+                        description: >
+                          Datetime in ISO format informing about when the analysis
+                          has started.
+                      state:
+                        type: string
+                        example: terminated
+                  parameters:
+                    type: object
+                    description: Parameters echoed back to user for debugging.
+        "400":
+          description: On invalid request.
+          content:
+            application/json:
+              schema:
+                <<: *analysisResponseError

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -988,9 +988,15 @@ paths:
     post:
       tags: [Package Analyzer]
       x-openapi-router-controller: thoth.management_api.api_v1
-      operationId: analyze_package
+      operationId: post_analyze_package
       summary: Gather digests of packages and files present inside packages.
       parameters:
+        - name: secret
+          in: query
+          required: true
+          description: A secret to schedule analysis of the given Python package.
+          schema:
+            type: string
         - name: package_name
           in: query
           required: true

--- a/thoth/management_api/api_v1.py
+++ b/thoth/management_api/api_v1.py
@@ -462,9 +462,13 @@ def _do_schedule(parameters: dict, runner: typing.Callable, **runner_kwargs):
     )
 
 
-def analyze_package(package_name: str, package_version: str, index_url: str, debug: bool):
+def post_analyze_package(secret: str, package_name: str, package_version: str, index_url: str, debug: bool):
     """Fetch digests for packages in Python ecosystem."""
+    if secret != Configuration.THOTH_MANAGEMENT_API_TOKEN:
+        return {"error": "Wrong secret provided"}, 401
+
     parameters = locals()
+    parameters.pop("secret")
 
     return _do_schedule(
         parameters,

--- a/thoth/management_api/api_v1.py
+++ b/thoth/management_api/api_v1.py
@@ -28,6 +28,7 @@ from thoth.storages import GraphDatabase
 from thoth.storages.graph.models import ALL_PERFORMANCE_MODELS
 from thoth.storages import SolverResultsStore
 from thoth.storages import DependencyMonkeyReportsStore
+from thoth.storages import PackageAnalysisResultsStore
 from thoth.storages.exceptions import NotFoundError
 
 from .configuration import Configuration
@@ -470,3 +471,23 @@ def analyze_package(package_name: str, package_version: str, index_url: str, deb
         _OPENSHIFT.schedule_package_analyzer,
         output=Configuration.THOTH_PACKAGE_ANALYZER_OUTPUT
     )
+
+
+def get_analyze_package(analysis_id: str):
+    """Retrieve the given package analyzer result."""
+    return _get_document(
+        PackageAnalysisResultsStore,
+        analysis_id,
+        name_prefix="package-analyzer-",
+        namespace=Configuration.THOTH_MIDDLETIER_NAMESPACE,
+    )
+
+
+def get_analyze_package_log(analysis_id: str):
+    """Get package analyzer log."""
+    return _get_job_log(locals(), "package-analyzer", Configuration.THOTH_MIDDLETIER_NAMESPACE)
+
+
+def get_analyze_package_status(analysis_id: str):
+    """Get status of an ecosystem package-analyzer."""
+    return _get_job_status(locals(), "package-analyzer", Configuration.THOTH_MIDDLETIER_NAMESPACE)


### PR DESCRIPTION
- Added endpoint GET `/package-analyzer/{analysis_id}` to management API to retrieve package-analyzer results
- Added endpoint GET `/package-analyzer/{analysis_id}/log` to management API to retrieve logs of a package-analyzer run
- Added endpoint GET `/package-analyzer/{analysis_id}/status` to management API to retrieve logs of a package-analyzer run
- Added a secret to `post_analyze_package`