### PR TITLE
Initialize schema on fresh deployment based on env variable

### DIFF
--- a/openshift/deployment-template.yaml
+++ b/openshift/deployment-template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     description: "This is Thoth - Management API"
     openshift.io/display-name: "Thoth Core: Management API"
-    version: 0.9.0
+    version: 0.9.1
     tags: thoth,management-api,ai-stacks,aistacks
     template.openshift.io/documentation-url: https://github.com/Thoth-Station/
     template.openshift.io/long-description: >

--- a/openshift/deployment-template.yaml
+++ b/openshift/deployment-template.yaml
@@ -91,12 +91,14 @@ objects:
           serviceAccountName: "${SERVICE_ACCOUNT_NAME}"
           containers:
             - name: management-api-openapi
-              env: &env
+              env:
                 - name: APP_MODULE
                   value: "thoth.management_api.openapi_server:app"
                 - name: KUBERNETES_API_URL
                   value: "https://kubernetes.default.svc.cluster.local"
                 - name: KUBERNETES_VERIFY_TLS
+                  value: "0"
+                - name: THOTH_MANAGEMENT_API_RUN_MIGRATIONS
                   value: "0"
                 - name: AMUN_API_URL
                   valueFrom:

--- a/thoth/management_api/openapi_server.py
+++ b/thoth/management_api/openapi_server.py
@@ -102,6 +102,13 @@ def before_request_callback():
             _API_GAUGE_METRIC.set(0)
 
 
+@application.before_first_request
+def before_first_request_callback():
+    """Callback registered, runs before first request to this service."""
+    if bool(int(os.getenv("THOTH_MANAGEMENT_API_RUN_MIGRATIONS", 0))):
+        GRAPH.initialize_schema()
+
+
 @app.route("/")
 @metrics.do_not_track()
 def base_url():


### PR DESCRIPTION
This way we will not need to manually trigger the initialization endpoint to
update the schema to the latest version in test deployment. It's especially
usefull for thoth-storages update - test environment can bump schema version
automatically.