### PR TITLE
Allow additional properties in context

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -564,6 +564,7 @@ paths:
                     }
                 context:
                   type: object
+                  additionalProperties: true
                   required:
                     - base
                   properties:


### PR DESCRIPTION
This way there is no need to update/redeploy management-api on every change on
Amun and parameters can be propagated.