### PR TITLE
Add maintainers

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -21,6 +21,8 @@ managers:
       maintainers:
         - fridex
         - goern
+        - sesheta
+        - pacospace
       assignees:
         - sesheta
       labels: [bot]


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Sesheta and pacospace cannot release.

https://github.com/thoth-station/management-api/issues/500

https://github.com/thoth-station/management-api/issues/496