### PR TITLE
Openapi schema fix

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -64,7 +64,7 @@ paths:
             Index URL to be used for solver analysis.
           schema:
             type: string
-            default: false
+            example: "https://pypi.org/simple"
       requestBody:
         required: true
         description: Python package that should be registered.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -65,6 +65,7 @@ paths:
           schema:
             type: string
             example: "https://pypi.org/simple"
+            nullable: true
       requestBody:
         required: true
         description: Python package that should be registered.


### PR DESCRIPTION
## Related Issues and Dependencies

```
connexion.exceptions.InvalidSpecification: False is not of type 'string'

Failed validating 'type' in schema:
    {'default': False, 'type': 'string'}
```

## This introduces a breaking change

- [x] No
<!--- Describe your changes in detail -->
