### PR TITLE
Remove /graph/version endpoint

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1184,16 +1184,6 @@ paths:
         "200":
           description: A list of available performance indicators
 
-  /graph/version:
-    get:
-      tags: [Graph]
-      x-openapi-router-controller: thoth.management_api.api_v1
-      operationId: get_graph_version
-      summary: Get version of Thoth's graph adapter implementation.
-      responses:
-        "200":
-          description: Version string of Thoth's
-
   /graph/initialize:
     put:
       tags: [Graph]

--- a/thoth/management_api/api_v1.py
+++ b/thoth/management_api/api_v1.py
@@ -28,7 +28,6 @@ from typing import Tuple
 
 from thoth.common import OpenShift
 from thoth.common.exceptions import NotFoundException as OpenShiftNotFound
-from thoth.storages import __version__ as thoth_storages_version
 from thoth.storages.graph.models_performance import ALL_PERFORMANCE_MODELS
 from thoth.storages import SolverResultsStore
 from thoth.storages import DependencyMonkeyReportsStore
@@ -282,11 +281,6 @@ def post_analyze(
     )
 
     return response, status_code
-
-
-def get_graph_version():
-    """Get version of Thoth's storages package installed."""
-    return {"thoth-storages": thoth_storages_version}, 200
 
 
 def get_performance_indicators():


### PR DESCRIPTION
## Related Issues and Dependencies

This endpoint is obsolete, the information it provided is available via metrics.

## This introduces a breaking change

- [x] No
