### PR TITLE
Remove version clash boot from the example

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -631,8 +631,6 @@ paths:
                     boots:
                       - name: "UbiBoot"
                         configuration: {}
-                      - name: "VersionClashBoot"
-                        configuration: {}
                     sieves:
                       - name: "CutLockedSieve"
                         configuration: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/adviser/issues/1712

## This introduces a breaking change

- [x] No
