### PR TITLE
Allow passing dependency indexes to the solver workflow

### DIFF
--- a/thoth/management_api/api_v1.py
+++ b/thoth/management_api/api_v1.py
@@ -117,6 +117,7 @@ def post_solve_python(
 
     packages = package_name + (version_specifier if version_specifier else "")
 
+    all_indexes = GRAPH.get_python_package_index_urls_all(enabled=True)
     if index_url:
         try:
             if not GRAPH.is_python_package_index_enabled(url=index_url):
@@ -138,11 +139,12 @@ def post_solve_python(
 
         indexes = [index_url]
     else:
-        indexes = GRAPH.get_python_package_index_urls_all(enabled=True)
+        indexes = all_indexes
 
     run_parameters = {
         "packages": packages,
         "indexes": indexes,
+        "dependency_indexes": all_indexes,
         "debug": debug,
         "transitive": transitive,
         "force_sync": force_sync,


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/solver/issues/5111
Related: https://github.com/thoth-station/graph-refresh-job/issues/669
Related: https://github.com/thoth-station/thoth-application/issues/2272

## This introduces a breaking change

- [x] No

## Description

Allow passing new environment variable for solvers, which would check indexes for possible dependencies (cross-index resolution).
