### PR TITLE
Use py38 as default in api schema

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1720,7 +1720,7 @@ components:
         amun_api_url:
           type: string
           description: Amun API host to which this deployment talks to (set to null if no Amun deployment is used).
-          example: "https://amun-api.thoth.redhat.com/"
+          example: "https://amun.prod.thoth-station.ninja"
           nullable: true
         frontend_namespace:
           type: string


### PR DESCRIPTION
## This introduces a breaking change

- No

## This Pull Request implements

- Use `python3.8` as a default value for the dependency-monkey endpoint.
- Fix url to amun-api 