### PR TITLE
Enable sync job to be called from the management api

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1670,6 +1670,57 @@ paths:
         "500":
           description: On server side errors.
 
+  /graph/sync-job:
+    post:
+      tags: [Graph]
+      x-openapi-router-controller: thoth.management_api.api_v1
+      operationId: schedule_sync_job
+      summary: Trigger the Sync job for solver documents
+      parameters:
+        - name: secret
+          in: query
+          required: true
+          description: A secret to schedule the job.
+          schema:
+            type: string
+        - name: document_type
+          in: query
+          required: true
+          description: >
+            The type of document to trigger the sync job for. The various document options are as follows.
+              * `adviser` - Sync adviser ceph documents
+              * `solver` - Sync solver ceph documents
+              * `revsolver` - Sync reverse solver ceph documents
+              * `package-extract` - Sync package metadata documents
+              * `prrovenance-checker` - Sync provenance-checker ceph documents
+              * `security-indicators` - Synce CVE ceph documents
+          schema:
+            type:  string
+            enum:
+              - adviser
+              - solver
+              - revsolver
+              - package-extract
+              - provenance-checker
+              - security-indicators
+        - name: force
+          in: query
+          required: false
+          description: Perform force sync of documents.
+          schema:
+            type: string
+        - name: graceful
+          in: query
+          required: false
+          description: Continue on any error during the sync.
+          schema:
+            type: string
+      responses:
+        "201":
+          description: The Sync Job was triggerred successfully.
+        "400":
+          description: On invalid request.
+
   /graph/refresh:
     post:
       tags: [Graph]

--- a/thoth/management_api/api_v1.py
+++ b/thoth/management_api/api_v1.py
@@ -26,6 +26,7 @@ from typing import Optional
 from typing import Dict
 from typing import Tuple
 
+
 from thoth.common import OpenShift
 from thoth.common import parse_datetime
 from thoth.common.exceptions import NotFoundExceptionError as OpenShiftNotFound
@@ -325,6 +326,23 @@ def schedule_graph_refresh(secret: str):
 
     job_id = _OPENSHIFT.schedule_graph_refresh()
     return {"job_id": job_id}, 201
+
+
+def schedule_sync_job(
+    secret: str,
+    document_type: Optional[str],
+    force_sync: bool = False,
+    graceful: bool = True,
+):
+    """Schedule the sync job for a document type."""
+    if secret != Configuration.THOTH_MANAGEMENT_API_TOKEN:
+        return {"error": "Wrong secret provided"}, 401
+    workflow_id = _OPENSHIFT.schedule_sync_job(
+        document_type=document_type,
+        force_sync=force_sync,
+        graceful=graceful,
+    )
+    return {"workflow_id": workflow_id}, 201
 
 
 def get_dependency_monkey_report(analysis_id: str) -> tuple:


### PR DESCRIPTION
## Related Issues and Dependencies

Partially addresses: https://github.com/thoth-station/thoth-application/issues/2513 (task 3 / 4)
Related-to: https://github.com/thoth-station/management-api/issues/887

## This introduces a breaking change

- [ ] Yes
- [x] No


## This Pull Request implements

New post endpoints for `/graph/sync-job/{component-name}`, that will trigger the sync job for those documents.
Component names:
1. adviser
2. solver
3. revsolver
4. package-extract
5. provenance-checker
6. security-indicators

/cc @harshad16 @fridex 