### PR TITLE
Fix: To check if 'warehouse_api_url' key exists

### DIFF
--- a/thoth/management_api/api_v1.py
+++ b/thoth/management_api/api_v1.py
@@ -73,7 +73,7 @@ def post_register_python_package_index(
 
     GRAPH.register_python_package_index(
         url=index["url"],
-        warehouse_api_url=index["warehouse_api_url"],
+        warehouse_api_url=index.get("warehouse_api_url", None),
         verify_ssl=index["verify_ssl"] if index.get("verify_ssl") is not None else True,
         enabled=enabled,
         only_if_package_seen=index["only_if_package_seen"],


### PR DESCRIPTION

## Related Issues and Dependencies
Fix for https://github.com/thoth-station/management-api/issues/863

## Description
Code will check if key 'warehouse_api_url' exists in the dict, if not sets None as default