### PR TITLE
Fix the description of index_url in /python/package-index/state

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1506,7 +1506,7 @@ paths:
         - name: index_url
           in: query
           required: true
-          description: URL to the Python simple repository as described in PEP 503.
+          description: URL to the Python package index to enable or disable.
           schema:
             type: string
             example: "https://pypi.org/simple"

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1506,7 +1506,7 @@ paths:
         - name: index_url
           in: query
           required: true
-          description: A secret to register the given Python package index.
+          description: URL to the Python simple repository as described in PEP 503.
           schema:
             type: string
             example: "https://pypi.org/simple"


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements


Fix the description of index_url in /python/package-index/state

I'm pretty sure that index_url is not a secret, given the rest of the endpoint
and the register one.
