### PR TITLE
Get flake8 config out of pre-commit config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+ignore =
+    E2,
+    W5
+select =
+    E,
+    W,
+    F,
+    N
+max-line-length = 120

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,5 +52,3 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: ['pep8-naming']
-        # Ignore all format-related checks as Black takes care of those.
-        args: ['--ignore', 'E2,W5', '--select', 'E,W,F,N', '--max-line-length=120']


### PR DESCRIPTION
This allow to use flake8 with local dev tools (python-language-server in
particular)
