### PR TITLE
Tentative fix for aicoe-ci/build-check

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -2,7 +2,7 @@ check:
   - thoth-build
 build:
   base-image: quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.33.0
-  build-stratergy: Source
+  build-strategy: Source
   registry: quay.io
   registry-org: thoth-station
   registry-project: management-api


### PR DESCRIPTION
## Related Issues and Dependencies

All currents PRs seems blocked by aicoe-ci/build-check 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Description

Fix what looks like a typo in .aicoe-ci.yaml, in the case it's related to the
build-check failing.
