### PR TITLE
:recycle: Correct the error type for exception handle in get_log

### DIFF
--- a/thoth/management_api/api_v1.py
+++ b/thoth/management_api/api_v1.py
@@ -593,7 +593,7 @@ def _get_log(
     result: typing.Dict[str, typing.Any] = {"parameters": {"analysis_id": analysis_id}}
     try:
         log = _OPENSHIFT.get_workflow_node_log(node_name, analysis_id, namespace)
-    except NotFoundError as exc:
+    except OpenShiftNotFound as exc:
         _LOGGER.exception(f"Log for {analysis_id} were not found: {str(exc)}")
         d: typing.Dict[str, Any] = {
             "error": f"Log for analysis {analysis_id} was not found or it has not started yet"


### PR DESCRIPTION
Correct the error type for exception handle in get_log
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/management-api/issues/920

## Description

The exception would be handled properly and give 404 not found, instead of 500 internal error.